### PR TITLE
muduplay.cc: Fixed MIDI player build with disabled puzzle game

### DIFF
--- a/src/midiplay.cc
+++ b/src/midiplay.cc
@@ -8,6 +8,7 @@
 #include <set>
 #include <cstdlib>
 #include <cstring>
+#include <cstdint>
 #include <cmath>
 #include <unistd.h>
 #include <stdarg.h>


### PR DESCRIPTION
Because of the missing `<cstdint>` include that gets unavalable when built with disabled puzzle game.

Fixes #16
